### PR TITLE
SAPHY-43 refactor: 카카오 로그인 수정

### DIFF
--- a/src/main/java/saphy/saphy/auth/config/SecurityConfig.java
+++ b/src/main/java/saphy/saphy/auth/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring().requestMatchers(
-                "/oauth/**"
+                "/oauth"
         );
     }
 

--- a/src/main/java/saphy/saphy/auth/presentation/KakaoController.java
+++ b/src/main/java/saphy/saphy/auth/presentation/KakaoController.java
@@ -35,20 +35,11 @@ public class KakaoController {
         if (isRegistered) {
             // 이미 회원인 경우 - 로그인 처리 및 토큰 발급
             tokenService.addTokensToResponse(request, response);
+            return new ApiResponse<>(ErrorCode.REQUEST_OK);
         } else {
-            // 회원이 아닌 경우 - 회원가입 처리 후 로그인 및 토큰 발급
-            KakaoSignUpDto signUpDto = KakaoSignUpDto.builder()
-                    .email(kakaoDto.getEmail())
-                    .socialType(kakaoDto.getSocialType())
-                    // 여기에 필요한 추가 필드들(name, phoneNumber 등)을 플러터에서 받을 수 있다면 포함
-                    // 뭔가 내 생각엔 null이 많더라도 바로 회원가입이 예뻐보이긴 하는데 일단 아래꺼 있으니 그냥 두고 연동하면서 수정 예정
-                    .build();
-
-            kaKaoService.joinKakao(signUpDto);
-            tokenService.addTokensToResponse(request, response);
+            // 회원이 아닌 경우 - 300 Multiple Choices 리다이렉션 처리
+            return new ApiResponse<>(ErrorCode.MEMBER_JOIN_REQUIRED);
         }
-
-        return new ApiResponse<>(ErrorCode.REQUEST_OK);
     }
 
     @PostMapping("/join")

--- a/src/main/java/saphy/saphy/global/exception/ErrorCode.java
+++ b/src/main/java/saphy/saphy/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 	DUPLICATE_MEMBER_PHONE_NUMBER(HttpStatus.CONFLICT, "중복된 전화번호입니다"),
 
 	// auth
+	MEMBER_JOIN_REQUIRED(HttpStatus.MULTIPLE_CHOICES, "회원가입이 필요합니다."),
 	TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰을 찾을 수 없습니다."),
 	EXPIRED_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 로그인 토큰입니다."),
 	INVALID_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 로그인 토큰입니다."),


### PR DESCRIPTION
## 📄 Summary

> 카카오 로그인 시 회원이 아닌 경우 300 응답 코드를 반환하도록 수정했습니다.

## 🕰️ Actual Time of Completion

> 20분

## 🙋🏻 More

>
