### PR TITLE
refactor: JPA ddl-auto 설정을 create로 수정한다

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
   jpa:
     show-sql: 'false'
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     open-in-view: 'false'
     database-platform: org.hibernate.dialect.MySQLDialect
 


### PR DESCRIPTION
## 📄 Summary

> 서버에서 로그인 API를 호출 시 DataIntegrityViolationException 에러가 발생하여 기존 테이블을 업데이트 하고자 application.yml의 JPA ddl-auto 설정을 create로 수정합니다.

## 🕰️ Actual Time of Completion

>

## 🙋🏻 More

>
