### PR TITLE
SAPHY-138 refactor: PATCH 추가

### DIFF
--- a/src/main/java/saphy/saphy/auth/config/SecurityConfig.java
+++ b/src/main/java/saphy/saphy/auth/config/SecurityConfig.java
@@ -78,7 +78,9 @@ public class SecurityConfig {
                         .configurationSource(new CorsConfigurationSource() {
                             @Override
                             public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+
                                 CorsConfiguration configuration = new CorsConfiguration();
+
                                 configuration.setAllowedOrigins(Arrays.asList("https://saphy.site", "http://localhost:8080", "http://localhost:3000"));
                                 configuration.setAllowedMethods(Collections.singletonList("*"));
                                 configuration.setAllowCredentials(true);

--- a/src/main/java/saphy/saphy/auth/config/SecurityConfig.java
+++ b/src/main/java/saphy/saphy/auth/config/SecurityConfig.java
@@ -79,8 +79,7 @@ public class SecurityConfig {
                             @Override
                             public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
                                 CorsConfiguration configuration = new CorsConfiguration();
-//                                configuration.setAllowedOrigins(Arrays.asList("http://localhost:8080", "http://localhost:3000", "https://saphy.site"));
-                                configuration.setAllowedOrigins(Collections.singletonList("*"));
+                                configuration.setAllowedOrigins(Arrays.asList("https://saphy.site", "http://localhost:8080", "http://localhost:3000"));
                                 configuration.setAllowedMethods(Collections.singletonList("*"));
                                 configuration.setAllowCredentials(true);
                                 configuration.setAllowedHeaders(Collections.singletonList("*"));
@@ -89,26 +88,6 @@ public class SecurityConfig {
                                 return configuration;
                             }
                         }));
-
-//        http
-//                .cors((cors) -> cors
-//                        .configurationSource((new CorsConfigurationSource() {
-//
-//                            @Override
-//                            public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
-//
-//                                CorsConfiguration configuration = new CorsConfiguration();
-//
-//                                configuration.setAllowedOrigins(Collections.singletonList("*"));
-//                                configuration.setAllowedMethods(Collections.singletonList("*"));
-//                                configuration.setAllowCredentials(true);
-//                                configuration.setAllowedHeaders(Collections.singletonList("*"));
-//                                configuration.setMaxAge(3600L);
-//                                configuration.setExposedHeaders(Collections.singletonList("Authorization"));
-//
-//                                return configuration;
-//                            }
-//                        })));
 
         http
                 .csrf(AbstractHttpConfigurer::disable);

--- a/src/main/java/saphy/saphy/global/config/CorsMvcConfig.java
+++ b/src/main/java/saphy/saphy/global/config/CorsMvcConfig.java
@@ -11,13 +11,11 @@ public class CorsMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry corsRegistry) {
 
         corsRegistry.addMapping("/**")
-//                .allowedOrigins("https://saphy.site/", "http://localhost:8080", "http://localhost:3000")
-                .allowedOrigins("*")
-//                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
+                .allowedOrigins("https://saphy.site/", "http://localhost:8080", "http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
                 .allowedMethods("*")
                 .allowedHeaders("Authorization", "Content-Type")
                 .exposedHeaders("Authorization")
                 .allowCredentials(true);
     }
-
 }


### PR DESCRIPTION
## 📄 Summary

> CORS 관련 HTTP 메서드에 PATCH 추가
> setAllowedOrigins와 setAllowCredentials 오류 해결

## 🕰️ Actual Time of Completion

> 15분

## 🙋🏻 More

> allowCredentials가 true일 경우 allowedOrigins에 와일드카드(*) 사용이 불가하기 때문에 저희가 쓰는 특정 경로로 바꿨습니다.(CORS 규칙)
