### PR TITLE
SAPHY-147 refactor: access 및 refresh token 만료주기 주입 방식 변경

### DIFF
--- a/src/main/java/saphy/saphy/auth/filter/LoginFilter.java
+++ b/src/main/java/saphy/saphy/auth/filter/LoginFilter.java
@@ -7,7 +7,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -31,12 +30,6 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     private final RefreshRepository refreshRepository;
     private final JWTUtil jwtUtil;
     private final ObjectMapper objectMapper = new ObjectMapper();
-
-    @Value("${spring.jwt.access-token-expiration}")
-    private long accessTokenExpiration;
-
-    @Value("${spring.jwt.refresh-token-expiration}")
-    private long refreshTokenExpiration;
 
     public LoginFilter(
             AuthenticationManager authenticationManager,
@@ -82,9 +75,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         // 인증에 성공한 loginId 받아오기
         String loginId = authResult.getName();
 
-        // 토큰 생성
-        String accessToken = jwtUtil.createJwt("access", loginId, accessTokenExpiration);
-        String refresh = jwtUtil.createJwt("refresh", loginId, refreshTokenExpiration);
+        // 토큰 생성(스프링 내부 로직에 접근하기 전,
+        String accessToken = jwtUtil.createJwt("access", loginId, 604800000L);
+        String refresh = jwtUtil.createJwt("refresh", loginId, 604800000L);
 
         response.addHeader("Authorization", "Bearer " + accessToken);// 헤더에 access 토큰 넣기
         response.addHeader("Set-Cookie", createCookie("refresh", refresh).toString()); // 쿠키 생성일 추가

--- a/src/main/java/saphy/saphy/auth/service/ReissueService.java
+++ b/src/main/java/saphy/saphy/auth/service/ReissueService.java
@@ -4,7 +4,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import saphy.saphy.auth.domain.repository.RefreshRepository;
@@ -18,19 +17,13 @@ public class ReissueService {
     private final JWTUtil jwtUtil;
     private final RefreshRepository refreshRepository;
 
-    @Value("${spring.jwt.access-token-expiration}")
-    private long accessTokenExpiration;
-
-    @Value("${spring.jwt.refresh-token-expiration}")
-    private long refreshTokenExpiration;
-
     public String createNewAccessToken(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = getRefreshTokenFromCookies(request); // 쿠키에서 토큰 추출
         String loginId = validateAndGetUserEmail(refreshToken); // 추출한 토큰 검증 및 유저반환
 
         //토큰 생성
-        String newAccess = jwtUtil.createJwt("access", loginId, accessTokenExpiration);
-        String newRefresh = jwtUtil.createJwt("refresh", "fakeLoginId", refreshTokenExpiration);
+        String newAccess = jwtUtil.createJwt("access", loginId, 604800000L);
+        String newRefresh = jwtUtil.createJwt("refresh", "fakeLoginId", 604800000L);
 
         // 새로운 refresh 토큰 쿠키에 삽입
         response.addHeader("Set-Cookie", createCookie("refresh", newRefresh).toString());

--- a/src/main/java/saphy/saphy/global/config/CorsMvcConfig.java
+++ b/src/main/java/saphy/saphy/global/config/CorsMvcConfig.java
@@ -9,7 +9,7 @@ public class CorsMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry corsRegistry) {
         corsRegistry.addMapping("/**")
-                .allowedOrigins("https://saphy.site/", "http://localhost:8080", "http://localhost:3000")
+                .allowedOrigins("https://saphy.site", "http://localhost:8080", "http://localhost:3000")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
                 .allowedHeaders("Authorization", "Content-Type")
                 .exposedHeaders("Authorization")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,8 +21,6 @@ spring:
   # JWT 설정 추가
   jwt:
     secret-key: ${JWT_SECRET}
-    access-token-expiration: 604800000 # 7 days
-    refresh-token-expiration: 604800000  # 7 days
 
   # PortOne
   portone:


### PR DESCRIPTION
## 📄 Summary

> CORS 허용 경로 오타 수정
> 기존에 yml로 주입 받던 access token과 refresh token의 만료주기를 필터 내에서 주입 받도록 변경

## 🕰️ Actual Time of Completion

> 20분

## 🙋🏻 More

> 로그인을 통해 인증된 사용자인지 여러 필터들을 통해 검증하는데, 
좀 더 좁은 범위인 yml에서 만료주기를 받게되면 오류가 발생하거나 잠재적인 오류 원인이 될 수 있음. 
따라서 필터 내에서 만료주기를 주입 받는 것이 더 적합하다고 생각해서 수정합니당
