### PR TITLE
SAPHY-167 feat: 기기 조회 기능 개편

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 
 	// AWS S3 SDK
 	implementation("com.amazonaws:aws-java-sdk-s3:1.12.174")
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+	implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
+	implementation 'javax.activation:activation:1.1.1'
 
 	// PortOne
 	implementation 'com.github.iamport:iamport-rest-client-java:0.1.6'

--- a/src/main/java/saphy/saphy/global/exception/ErrorCode.java
+++ b/src/main/java/saphy/saphy/global/exception/ErrorCode.java
@@ -71,6 +71,7 @@ public enum ErrorCode {
     ITEM_SIZE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "해당 사이즈의 제품이 재고가 없습니다."),
     ITEM_MODEL_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "해당 모델의 제품이 재고가 없습니다."),
     ITEM_DISCONTINUED(HttpStatus.BAD_REQUEST, "단종된 제품입니다."),
+    INVALID_DEVICE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 기기 타입입니다."),
 
     // chat
     CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),

--- a/src/main/java/saphy/saphy/image/service/ImageService.java
+++ b/src/main/java/saphy/saphy/image/service/ImageService.java
@@ -25,7 +25,7 @@ import saphy.saphy.image.repository.ItemImageRepository;
 import saphy.saphy.image.repository.ProfileImageRepository;
 import saphy.saphy.image.repository.ReviewImageRepository;
 import saphy.saphy.item.domain.Item;
-import saphy.saphy.item.repository.ItemRepository;
+import saphy.saphy.item.domain.repository.ItemRepository;
 import saphy.saphy.member.domain.Member;
 import saphy.saphy.member.domain.repository.MemberRepository;
 import saphy.saphy.review.domain.Review;

--- a/src/main/java/saphy/saphy/item/domain/Item.java
+++ b/src/main/java/saphy/saphy/item/domain/Item.java
@@ -8,6 +8,8 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -22,6 +24,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import saphy.saphy.global.entity.BaseEntity;
 import saphy.saphy.image.domain.ItemImage;
+import saphy.saphy.item.domain.enumeration.DeviceType;
 
 @Entity
 @Getter
@@ -37,8 +40,9 @@ public class Item extends BaseEntity {
     @Column(name = "item_id")
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     @Column(insertable = false, updatable = false)
-    private String deviceType;
+    private DeviceType deviceType;
 
     @Column(name = "name", nullable = false)
     private String name;

--- a/src/main/java/saphy/saphy/item/domain/repository/ItemRepository.java
+++ b/src/main/java/saphy/saphy/item/domain/repository/ItemRepository.java
@@ -1,4 +1,4 @@
-package saphy.saphy.item.repository;
+package saphy.saphy.item.domain.repository;
 
 import java.util.List;
 

--- a/src/main/java/saphy/saphy/item/dto/request/LaptopCreateRequest.java
+++ b/src/main/java/saphy/saphy/item/dto/request/LaptopCreateRequest.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import saphy.saphy.item.domain.Laptop;
 import saphy.saphy.item.domain.enumeration.Brand;
 import saphy.saphy.item.domain.enumeration.Color;
+import saphy.saphy.item.domain.enumeration.DeviceType;
 import saphy.saphy.item.domain.enumeration.Grade;
 import saphy.saphy.item.domain.enumeration.Graphics;
 import saphy.saphy.item.domain.enumeration.Memory;
@@ -41,7 +42,7 @@ public class LaptopCreateRequest {
 
 	public Laptop toEntity() {
 		return Laptop.builder()
-			.deviceType(deviceType)
+			.deviceType(DeviceType.findByName(deviceType))
 			.name(name)
 			.description(description)
 			.brand(Brand.findByName(brand))

--- a/src/main/java/saphy/saphy/item/dto/request/PhoneCreateRequest.java
+++ b/src/main/java/saphy/saphy/item/dto/request/PhoneCreateRequest.java
@@ -3,10 +3,10 @@ package saphy.saphy.item.dto.request;
 import java.math.BigDecimal;
 
 import lombok.Getter;
-import saphy.saphy.item.domain.Item;
 import saphy.saphy.item.domain.Phone;
 import saphy.saphy.item.domain.enumeration.Brand;
 import saphy.saphy.item.domain.enumeration.Color;
+import saphy.saphy.item.domain.enumeration.DeviceType;
 import saphy.saphy.item.domain.enumeration.Grade;
 import saphy.saphy.item.domain.enumeration.Storage;
 
@@ -33,7 +33,7 @@ public class PhoneCreateRequest {
 
 	public Phone toEntity() {
 		return Phone.builder()
-			.deviceType(deviceType)
+			.deviceType(DeviceType.findByName(deviceType))
 			.name(name)
 			.description(description)
 			.brand(Brand.findByName(brand))

--- a/src/main/java/saphy/saphy/item/dto/request/TabletCreateRequest.java
+++ b/src/main/java/saphy/saphy/item/dto/request/TabletCreateRequest.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import saphy.saphy.item.domain.Tablet;
 import saphy.saphy.item.domain.enumeration.Brand;
 import saphy.saphy.item.domain.enumeration.Color;
+import saphy.saphy.item.domain.enumeration.DeviceType;
 import saphy.saphy.item.domain.enumeration.Grade;
 import saphy.saphy.item.domain.enumeration.Storage;
 
@@ -32,7 +33,7 @@ public class TabletCreateRequest {
 
 	public Tablet toEntity() {
 		return Tablet.builder()
-			.deviceType(deviceType)
+			.deviceType(DeviceType.findByName(deviceType))
 			.name(name)
 			.description(description)
 			.brand(Brand.findByName(brand))

--- a/src/main/java/saphy/saphy/item/dto/response/ItemResponse.java
+++ b/src/main/java/saphy/saphy/item/dto/response/ItemResponse.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import saphy.saphy.image.dto.response.ImageResponse;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE) // ItemResponse는 상속을 위한 클래스로, 그 자체로 사용되지 않기 떄문에 생성자를 private로 설정한다.
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // ItemResponse는 상속을 위한 클래스로, 그 자체로 사용되지 않기 떄문에 생성자를 private로 설정한다.
 public class ItemResponse {
 	protected Long id;
 

--- a/src/main/java/saphy/saphy/item/dto/response/ItemResponse.java
+++ b/src/main/java/saphy/saphy/item/dto/response/ItemResponse.java
@@ -6,9 +6,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import saphy.saphy.image.dto.response.ImageResponse;
+import saphy.saphy.item.domain.Item;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED) // ItemResponse는 상속을 위한 클래스로, 그 자체로 사용되지 않기 떄문에 생성자를 private로 설정한다.
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ItemResponse {
 	protected Long id;
 
@@ -23,4 +24,20 @@ public class ItemResponse {
 	protected int stock;
 
 	protected List<ImageResponse> images;
+
+	public static ItemResponse from(Item item) {
+		ItemResponse response = new ItemResponse();
+
+		response.id = item.getId();
+		response.deviceType = item.getDeviceType().getName();
+		response.name = item.getName();
+		response.description = item.getDescription();
+		response.price = item.getPrice().intValue();
+		response.stock = item.getStock();
+		response.images = item.getImages().stream()
+			.map(itemImage -> ImageResponse.from(itemImage.getImage()))
+			.toList();
+
+		return response;
+	}
 }

--- a/src/main/java/saphy/saphy/item/dto/response/ItemResponse.java
+++ b/src/main/java/saphy/saphy/item/dto/response/ItemResponse.java
@@ -1,0 +1,26 @@
+package saphy.saphy.item.dto.response;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import saphy.saphy.image.dto.response.ImageResponse;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE) // ItemResponse는 상속을 위한 클래스로, 그 자체로 사용되지 않기 떄문에 생성자를 private로 설정한다.
+public class ItemResponse {
+	protected Long id;
+
+	protected String deviceType;
+
+	protected String name;
+
+	protected String description;
+
+	protected int price;
+
+	protected int stock;
+
+	protected List<ImageResponse> images;
+}

--- a/src/main/java/saphy/saphy/item/dto/response/LaptopResponse.java
+++ b/src/main/java/saphy/saphy/item/dto/response/LaptopResponse.java
@@ -8,15 +8,7 @@ import saphy.saphy.item.domain.Laptop;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class LaptopResponse {
-	private Long id;
-
-	private String deviceType;
-
-	private String name;
-
-	private String description;
-
+public class LaptopResponse extends ItemResponse {
 	private String brand;
 
 	private String color;
@@ -30,10 +22,6 @@ public class LaptopResponse {
 	private String graphics;
 
 	private String grade;
-
-	private int price;
-
-	private int stock;
 
 	public static LaptopResponse from(Item item) {
 		LaptopResponse response = new LaptopResponse();

--- a/src/main/java/saphy/saphy/item/dto/response/LaptopResponse.java
+++ b/src/main/java/saphy/saphy/item/dto/response/LaptopResponse.java
@@ -3,6 +3,7 @@ package saphy.saphy.item.dto.response;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import saphy.saphy.image.dto.response.ImageResponse;
 import saphy.saphy.item.domain.Item;
 import saphy.saphy.item.domain.Laptop;
 
@@ -40,6 +41,9 @@ public class LaptopResponse extends ItemResponse {
 		response.grade = laptop.getGrade().getName();
 		response.price = laptop.getPrice().intValue();
 		response.stock = laptop.getStock();
+		response.images = item.getImages().stream()
+			.map(itemImage -> ImageResponse.from(itemImage.getImage()))
+			.toList();
 
 		return response;
 	}

--- a/src/main/java/saphy/saphy/item/dto/response/LaptopResponse.java
+++ b/src/main/java/saphy/saphy/item/dto/response/LaptopResponse.java
@@ -40,7 +40,7 @@ public class LaptopResponse {
 
 		Laptop laptop = (Laptop) item;
 		response.id = laptop.getId();
-		response.deviceType = laptop.getDeviceType();
+		response.deviceType = laptop.getDeviceType().getName();
 		response.name = laptop.getName();
 		response.description = laptop.getDescription();
 		response.brand = laptop.getBrand().getName();

--- a/src/main/java/saphy/saphy/item/dto/response/PhoneResponse.java
+++ b/src/main/java/saphy/saphy/item/dto/response/PhoneResponse.java
@@ -1,7 +1,5 @@
 package saphy.saphy.item.dto.response;
 
-import java.util.List;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,15 +9,7 @@ import saphy.saphy.item.domain.Phone;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PhoneResponse {
-	private Long id;
-
-	private String deviceType;
-
-	private String name;
-
-	private String description;
-
+public class PhoneResponse extends ItemResponse {
 	private String brand;
 
 	private String color;
@@ -27,12 +17,6 @@ public class PhoneResponse {
 	private String storage;
 
 	private String grade;
-
-	private int price;
-
-	private int stock;
-
-	private List<ImageResponse> images;
 
 	public static PhoneResponse from(Item item) {
 		PhoneResponse response = new PhoneResponse();

--- a/src/main/java/saphy/saphy/item/dto/response/PhoneResponse.java
+++ b/src/main/java/saphy/saphy/item/dto/response/PhoneResponse.java
@@ -39,7 +39,7 @@ public class PhoneResponse {
 
 		Phone phone = (Phone) item;
 		response.id = phone.getId();
-		response.deviceType = phone.getDeviceType();
+		response.deviceType = phone.getDeviceType().getName();
 		response.name = phone.getName();
 		response.description = phone.getDescription();
 		response.brand = phone.getBrand().getName();

--- a/src/main/java/saphy/saphy/item/dto/response/TabletResponse.java
+++ b/src/main/java/saphy/saphy/item/dto/response/TabletResponse.java
@@ -3,6 +3,7 @@ package saphy.saphy.item.dto.response;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import saphy.saphy.image.dto.response.ImageResponse;
 import saphy.saphy.item.domain.Item;
 import saphy.saphy.item.domain.Tablet;
 
@@ -31,6 +32,9 @@ public class TabletResponse extends ItemResponse{
 		response.grade = tablet.getGrade().getName();
 		response.price = tablet.getPrice().intValue();
 		response.stock = tablet.getStock();
+		response.images = item.getImages().stream()
+			.map(itemImage -> ImageResponse.from(itemImage.getImage()))
+			.toList();
 
 		return response;
 	}

--- a/src/main/java/saphy/saphy/item/dto/response/TabletResponse.java
+++ b/src/main/java/saphy/saphy/item/dto/response/TabletResponse.java
@@ -8,15 +8,7 @@ import saphy.saphy.item.domain.Tablet;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TabletResponse {
-	private Long id;
-
-	private String deviceType;
-
-	private String name;
-
-	private String description;
-
+public class TabletResponse extends ItemResponse{
 	private String brand;
 
 	private String color;
@@ -24,10 +16,6 @@ public class TabletResponse {
 	private String storage;
 
 	private String grade;
-
-	private int price;
-
-	private int stock;
 
 	public static TabletResponse from(Item item) {
 		TabletResponse response = new TabletResponse();

--- a/src/main/java/saphy/saphy/item/dto/response/TabletResponse.java
+++ b/src/main/java/saphy/saphy/item/dto/response/TabletResponse.java
@@ -34,7 +34,7 @@ public class TabletResponse {
 
 		Tablet tablet = (Tablet) item;
 		response.id = tablet.getId();
-		response.deviceType = tablet.getDeviceType();
+		response.deviceType = tablet.getDeviceType().getName();
 		response.name = tablet.getName();
 		response.description = tablet.getDescription();
 		response.brand = tablet.getBrand().getName();

--- a/src/main/java/saphy/saphy/item/presentation/ItemController.java
+++ b/src/main/java/saphy/saphy/item/presentation/ItemController.java
@@ -79,14 +79,20 @@ public class ItemController {
 	}
 
 	@GetMapping("/items/all")
-	@Operation(summary = "상품 전체 조회 API", description = "전체 상품을 조회하는 API 입니다.")
-	public ApiResponse<PhoneResponse> findAllPhones() {
-		return new ApiResponse<>(itemService.findAllPhones());
+	@Operation(summary = "기기 종류에 따른 상품 조회 API", description = "기기 종류에 따라 상품 목록을 조회하는 API 입니다.")
+	public ApiResponse<ItemResponse> findAllItems(@RequestParam("type") String type) {
+		if (type.equals("ALL")) {
+			return new ApiResponse<>(itemService.findAllItems());
+		}
+		return new ApiResponse<>(itemService.findByDeviceType(type));
 	}
 
 	@DeleteMapping("/items/{itemId}")
 	@Operation(summary = "상품 삭제 API", description = "상품을 삭제하는 API 입니다.")
-	public ApiResponse<Void> delete(@AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable Long itemId) {
+	public ApiResponse<Void> delete(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable Long itemId
+	) {
 		Member loggedInMember = customUserDetails.getMember();
 		itemService.delete(loggedInMember, itemId);
 

--- a/src/main/java/saphy/saphy/item/presentation/ItemController.java
+++ b/src/main/java/saphy/saphy/item/presentation/ItemController.java
@@ -50,16 +50,24 @@ public class ItemController {
 
 	@PostMapping("/items/tablets")
 	@Operation(summary = "태블릿 생성 API", description = "상품을 생성하는 API 입니다.")
-	public ApiResponse<Void> save(@RequestBody TabletCreateRequest request) {
-		itemService.saveTablet(request);
+	public ApiResponse<Void> save(
+		@RequestPart("request") TabletCreateRequest request,
+		@RequestPart("imageFiles") List<MultipartFile> multipartFiles
+	) {
+		Item item = itemService.saveTablet(request);
+		imageService.saveItemImages(multipartFiles, item.getId());
 
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}
 
 	@PostMapping("/items/laptops")
 	@Operation(summary = "노트북 생성 API", description = "상품을 생성하는 API 입니다.")
-	public ApiResponse<Void> save(@RequestBody LaptopCreateRequest request) {
-		itemService.saveLaptop(request);
+	public ApiResponse<Void> save(
+		@RequestPart("request") LaptopCreateRequest request,
+		@RequestPart("imageFiles") List<MultipartFile> multipartFiles
+	) {
+		Item item = itemService.saveLaptop(request);
+		imageService.saveItemImages(multipartFiles, item.getId());
 
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}

--- a/src/main/java/saphy/saphy/item/presentation/ItemController.java
+++ b/src/main/java/saphy/saphy/item/presentation/ItemController.java
@@ -6,8 +6,8 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,13 +18,17 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import saphy.saphy.auth.domain.CustomUserDetails;
 import saphy.saphy.global.exception.ErrorCode;
+import saphy.saphy.global.exception.SaphyException;
 import saphy.saphy.global.response.ApiResponse;
 import saphy.saphy.image.service.ImageService;
 import saphy.saphy.item.domain.Item;
 import saphy.saphy.item.dto.request.LaptopCreateRequest;
 import saphy.saphy.item.dto.request.PhoneCreateRequest;
 import saphy.saphy.item.dto.request.TabletCreateRequest;
+import saphy.saphy.item.dto.response.ItemResponse;
+import saphy.saphy.item.dto.response.LaptopResponse;
 import saphy.saphy.item.dto.response.PhoneResponse;
+import saphy.saphy.item.dto.response.TabletResponse;
 import saphy.saphy.item.service.ItemService;
 import saphy.saphy.member.domain.Member;
 
@@ -74,8 +78,18 @@ public class ItemController {
 
 	@GetMapping("/items/{itemId}")
 	@Operation(summary = "상품 단건 조회 API", description = "상품을 단건으로 조회하는 API 입니다.")
-	public ApiResponse<PhoneResponse> findPhoneById(@PathVariable Long itemId) {
-		return new ApiResponse<>(itemService.findPhoneById(itemId));
+	public ApiResponse<? extends ItemResponse> findItemById(@PathVariable Long itemId) {
+		ItemResponse response = itemService.findItemById(itemId);
+
+		if (response instanceof PhoneResponse) {
+			return new ApiResponse<>((PhoneResponse) response);
+		} else if (response instanceof TabletResponse) {
+			return new ApiResponse<>((TabletResponse) response);
+		} else if (response instanceof LaptopResponse) {
+			return new ApiResponse<>((LaptopResponse) response);
+		} else {
+			throw SaphyException.from(ErrorCode.INVALID_DEVICE_TYPE);
+		}
 	}
 
 	@GetMapping("/items/all")

--- a/src/main/java/saphy/saphy/item/repository/ItemRepository.java
+++ b/src/main/java/saphy/saphy/item/repository/ItemRepository.java
@@ -1,8 +1,13 @@
 package saphy.saphy.item.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import saphy.saphy.item.domain.Item;
+import saphy.saphy.item.domain.enumeration.DeviceType;
 
 public interface ItemRepository<T extends Item> extends JpaRepository<T, Long> {
+	List<T> findByDeviceType(DeviceType deviceType);
+
 }

--- a/src/main/java/saphy/saphy/item/service/ItemService.java
+++ b/src/main/java/saphy/saphy/item/service/ItemService.java
@@ -50,7 +50,14 @@ public class ItemService {
 
 	public List<ItemResponse> findAllItems() {
 		return itemRepository.findAll().stream()
-			.map(PhoneResponse::from)
+			.map(ItemResponse::from)
+			.toList();
+	}
+
+	public List<ItemResponse> findByDeviceType(String deviceType) {
+		return itemRepository.findByDeviceType(DeviceType.valueOf(deviceType))
+			.stream()
+			.map(ItemResponse::from)
 			.toList();
 	}
 

--- a/src/main/java/saphy/saphy/item/service/ItemService.java
+++ b/src/main/java/saphy/saphy/item/service/ItemService.java
@@ -51,9 +51,10 @@ public class ItemService {
 	/**
 	 * 태블릿
 	 */
-	public void saveTablet(TabletCreateRequest request) {
+	public Item saveTablet(TabletCreateRequest request) {
 		Tablet tablet = request.toEntity();
-		itemRepository.save(tablet);
+
+		return itemRepository.save(tablet);
 	}
 
 	public TabletResponse findTabletById(Long itemId) {
@@ -71,9 +72,10 @@ public class ItemService {
 	/**
 	 * 노트북
 	 */
-	public void saveLaptop(LaptopCreateRequest request) {
+	public Item saveLaptop(LaptopCreateRequest request) {
 		Laptop laptop = request.toEntity();
-		itemRepository.save(laptop);
+
+		return itemRepository.save(laptop);
 	}
 
 	public LaptopResponse findLaptopById(Long itemId) {

--- a/src/main/java/saphy/saphy/item/service/ItemService.java
+++ b/src/main/java/saphy/saphy/item/service/ItemService.java
@@ -21,7 +21,7 @@ import saphy.saphy.item.dto.response.ItemResponse;
 import saphy.saphy.item.dto.response.LaptopResponse;
 import saphy.saphy.item.dto.response.PhoneResponse;
 import saphy.saphy.item.dto.response.TabletResponse;
-import saphy.saphy.item.repository.ItemRepository;
+import saphy.saphy.item.domain.repository.ItemRepository;
 import saphy.saphy.member.domain.Member;
 
 @Service

--- a/src/main/java/saphy/saphy/item/service/ItemService.java
+++ b/src/main/java/saphy/saphy/item/service/ItemService.java
@@ -48,7 +48,7 @@ public class ItemService {
 		return createResponseByDeviceType(deviceType, item);
 	}
 
-	public List<PhoneResponse> findAllPhones() {
+	public List<ItemResponse> findAllItems() {
 		return itemRepository.findAll().stream()
 			.map(PhoneResponse::from)
 			.toList();

--- a/src/main/java/saphy/saphy/item/service/ItemService.java
+++ b/src/main/java/saphy/saphy/item/service/ItemService.java
@@ -2,6 +2,7 @@ package saphy.saphy.item.service;
 
 import java.util.List;
 
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,9 +13,11 @@ import saphy.saphy.item.domain.Item;
 import saphy.saphy.item.domain.Laptop;
 import saphy.saphy.item.domain.Phone;
 import saphy.saphy.item.domain.Tablet;
+import saphy.saphy.item.domain.enumeration.DeviceType;
 import saphy.saphy.item.dto.request.LaptopCreateRequest;
 import saphy.saphy.item.dto.request.PhoneCreateRequest;
 import saphy.saphy.item.dto.request.TabletCreateRequest;
+import saphy.saphy.item.dto.response.ItemResponse;
 import saphy.saphy.item.dto.response.LaptopResponse;
 import saphy.saphy.item.dto.response.PhoneResponse;
 import saphy.saphy.item.dto.response.TabletResponse;
@@ -36,10 +39,13 @@ public class ItemService {
 		return itemRepository.save(phone);
 	}
 
-	public PhoneResponse findPhoneById(Long itemId) {
-		return itemRepository.findById(itemId)
-			.map(PhoneResponse::from)
-			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 휴대폰입니다."));
+	// deviceType 에 따라 각기 다른 응답을 반환하지만, 최종 반환형은 ItemResponse 로 통일. 이후 다시 자식 클래스로 형변환하여 자세한 정보를 전달
+	public ItemResponse findItemById(Long itemId) {
+		Item item = itemRepository.findById(itemId)
+			.orElseThrow(() -> SaphyException.from(ErrorCode.ITEM_NOT_FOUND));
+		DeviceType deviceType = item.getDeviceType();
+
+		return createResponseByDeviceType(deviceType, item);
 	}
 
 	public List<PhoneResponse> findAllPhones() {
@@ -91,9 +97,22 @@ public class ItemService {
 	}
 
 	public void delete(Member member, Long itemId) {
-		if(!member.getIsAdmin()){
+		if (!member.getIsAdmin()) {
 			throw SaphyException.from(ErrorCode.MEMBER_NOT_ADMIN);
 		}
 		itemRepository.deleteById(itemId);
+	}
+
+	// 이거 분명 더 깔끔하게 할 수 있을 것 같은데... 일단은 이렇게 구현해놓고 나중에 고쳐보겠습니다
+	private @NotNull ItemResponse createResponseByDeviceType(DeviceType deviceType, Item item) {
+		if (deviceType.equals(DeviceType.PHONE)) {
+			return PhoneResponse.from(item);
+		} else if (deviceType.equals(DeviceType.TABLET)) {
+			return TabletResponse.from(item);
+		} else if (deviceType.equals(DeviceType.LAPTOP)) {
+			return LaptopResponse.from(item);
+		} else {
+			throw SaphyException.from(ErrorCode.INVALID_DEVICE_TYPE);
+		}
 	}
 }

--- a/src/main/java/saphy/saphy/itemWish/service/ItemWishService.java
+++ b/src/main/java/saphy/saphy/itemWish/service/ItemWishService.java
@@ -6,15 +6,10 @@ import org.springframework.transaction.annotation.Transactional;
 import saphy.saphy.global.exception.ErrorCode;
 import saphy.saphy.global.exception.SaphyException;
 import saphy.saphy.item.domain.Item;
-import saphy.saphy.item.domain.Phone;
-import saphy.saphy.item.domain.Tablet;
-import saphy.saphy.item.repository.ItemRepository;
+import saphy.saphy.item.domain.repository.ItemRepository;
 import saphy.saphy.itemWish.domain.ItemWish;
 import saphy.saphy.itemWish.domain.repository.ItemWishRepository;
 import saphy.saphy.member.domain.Member;
-import saphy.saphy.member.domain.repository.MemberRepository;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## 📄 Summary

- 기존에 거의 김영한 스프링 기본편마냥 간단하게 구현해놨던 CRUD를 보다 체계적으로 개편했습니다.
  - 기존 상품 조회 API는 단순히 `PhoneResponse`만 반환했습니다.
  - But! 이제는 조회하는 상품의 기종에 따라 휴대폰이면 `PhoneResponse`, 노트북이면 `LaptopResposne`에 맞춰 반환됩니다.
  - 아래와 같이 `deviceType`이 휴대폰이냐, 노트북이냐에 따라 각기 다른 Response가 반환됩니다.

```json
{
    "status": {
        "code": 200,
        "message": "올바른 요청입니다."
    },
    "metadata": {
        "resultCount": 1
    },
    "results": [
        {
            "id": 1,
            "deviceType": "휴대폰",
            "name": "iPhone 16 Pro",
            "description": "이것은 아이폰 15 프로입니다.",
            "price": 990000,
            "stock": 20,
            "images": [
                {
                    "name": "iPhone 15 Blue 128gb.png",
                    "url": "https://modong-bucket.s3.ap-northeast-2.amazonaws.com/20240918141914_490aed92-b697-4710-b71b-7aaf014543db.png"
                }
            ],
            "brand": "Apple",
            "color": "블루",
            "storage": "128GB",
            "grade": "A등급"
        }
    ]
}
```

```json
{
    "status": {
        "code": 200,
        "message": "올바른 요청입니다."
    },
    "metadata": {
        "resultCount": 1
    },
    "results": [
        {
            "id": 2,
            "deviceType": "노트북",
            "name": "Macbook Pro 2020",
            "description": "이것은 맥북 프로입니다.",
            "price": 2990000,
            "stock": 20,
            "images": [
                {
                    "name": "맥북프로 이미지.jpg",
                    "url": "https://modong-bucket.s3.ap-northeast-2.amazonaws.com/20240918141917_3a0741ee-5a39-4150-978d-9564fd2da98c.jpg"
                }
            ],
            "brand": "Apple",
            "color": "실버",
            "storage": "512GB",
            "processor": "인텔 코어 i9",
            "memory": "32GB",
            "graphics": "RTX 4070",
            "grade": "A등급"
        }
    ]
}
```

- 근데... 코드가 솔직히 너무 마음에 안 듭니다.
  - 일단 `PhoneResponse`, `TabletResponse`, `LaptopResponse` 자체는 `ItemResponse`라는 공통의 부모 DTO를 상속받도록 설계했습니다.
  - 따라서 상품 조회시, 서비스 계층에서 일단 `ItemResponse`로 반환한 다음 API 호출 시점에서 `deviceType`에 따라 다시 Response를 바꿔줘야 하는데, 그러면 코드가 아래처럼 됩니다.
  - if-else 문 떡칠되어있는 것도 마음에 안 들고, 컨트롤러는 코드가 간결할수록 좋은데 이 로직을 서비스 계층에 숨길 수도 없다는 게 화가 납니다.
  - 추후에 `deviceType`에 따라 맞는 Response로 바꿔주는 Mapper 클래스를 만들어서 리팩토링해봐야 할 것 같습니다.

```java
@GetMapping("/items/{itemId}")
@Operation(summary = "상품 단건 조회 API", description = "상품을 단건으로 조회하는 API 입니다.")
public ApiResponse<? extends ItemResponse> findItemById(@PathVariable Long itemId) {
	ItemResponse response = itemService.findItemById(itemId);

	if (response instanceof PhoneResponse) {
		return new ApiResponse<>((PhoneResponse) response);
	} else if (response instanceof TabletResponse) {
		return new ApiResponse<>((TabletResponse) response);
	} else if (response instanceof LaptopResponse) {
		return new ApiResponse<>((LaptopResponse) response);
	} else {
		throw SaphyException.from(ErrorCode.INVALID_DEVICE_TYPE);
	}
}
```

## 🕰️ Actual Time of Completion

> 3 days

## 🙋🏻 More

> 이건 진짜 꼭 리팩토링한다
