### PR TITLE
SAPHY-182 fix: 사용자 조회 관련 에러 해결

### DIFF
--- a/src/main/java/saphy/saphy/image/domain/ProfileImage.java
+++ b/src/main/java/saphy/saphy/image/domain/ProfileImage.java
@@ -7,11 +7,13 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import saphy.saphy.member.domain.Member;
 
 @Entity
@@ -29,6 +31,7 @@ public class ProfileImage {
 	private Image image;
 
 	@OneToOne(fetch = FetchType.LAZY)
+	@Setter
 	private Member member;
 
 	/**
@@ -46,5 +49,9 @@ public class ProfileImage {
 		profileImage.member = member;
 
 		return profileImage;
+	}
+
+	public void updateMember(Member member) {
+		this.member = member;
 	}
 }

--- a/src/main/java/saphy/saphy/image/repository/ImageStoreProcessor.java
+++ b/src/main/java/saphy/saphy/image/repository/ImageStoreProcessor.java
@@ -33,7 +33,7 @@ public class ImageStoreProcessor {
 		return storeImageDtos;
 	}
 
-	private StoreImageDto storeImageFile(MultipartFile imageFile) {
+	public StoreImageDto storeImageFile(MultipartFile imageFile) {
 		String originalImageFileName = imageFile.getOriginalFilename();
 		String storeImageFileName = createStoreImageFileName(originalImageFileName); // 랜덤한 UUID를 통해 이미지 이름 설정
 

--- a/src/main/java/saphy/saphy/image/repository/ProfileImageRepository.java
+++ b/src/main/java/saphy/saphy/image/repository/ProfileImageRepository.java
@@ -3,16 +3,17 @@ package saphy.saphy.image.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import saphy.saphy.image.domain.ProfileImage;
 
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
 	Optional<ProfileImage> findByImage_StoreName(String storeName);
 
-	Optional<ProfileImage> findByMemberId(Long memberId);
+	// Optional<ProfileImage> findByMemberId(Long memberId);
 
-	// @Query("SELECT p FROM ProfileImage p JOIN FETCH p.member WHERE p.member.id = :memberId")
-	// Optional<ProfileImage> findByMemberIdJQL(Long memberId);
+	@Query("SELECT p FROM ProfileImage p JOIN FETCH p.member WHERE p.member.id = :memberId")
+	Optional<ProfileImage> findByMemberId(Long memberId);
 /*
 	@EntityGraph(attributePaths = { "url" })
 	Optional<String> fetchProfileImage();

--- a/src/main/java/saphy/saphy/member/domain/Member.java
+++ b/src/main/java/saphy/saphy/member/domain/Member.java
@@ -58,9 +58,9 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ItemWish> itemWishes = new ArrayList<>();
 
-    @OneToOne(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
-    @JoinColumn(name = "profile_image_id")
-    private ProfileImage profileImage;
+    public void updateProfileImage(ProfileImage profileImage) {
+        profileImage.setMember(this);
+    }
 
     /**
      * 주소

--- a/src/main/java/saphy/saphy/member/domain/repository/MemberRepository.java
+++ b/src/main/java/saphy/saphy/member/domain/repository/MemberRepository.java
@@ -1,8 +1,6 @@
 package saphy.saphy.member.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import saphy.saphy.member.domain.Member;
 import saphy.saphy.member.domain.SocialType;
@@ -17,7 +15,4 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Object> findByEmailAndSocialType(String email, SocialType socialType);
 
     Optional<Member> findByLoginIdAndSocialType(String loginId, SocialType socialType);
-
-    @Query("SELECT m FROM Member m LEFT JOIN FETCH m.profileImage WHERE m.id = :memberId")
-    Optional<Member> findWithImagesById(@Param("memberId") Long memberId);
 }

--- a/src/main/java/saphy/saphy/member/domain/repository/MemberRepository.java
+++ b/src/main/java/saphy/saphy/member/domain/repository/MemberRepository.java
@@ -1,6 +1,9 @@
 package saphy.saphy.member.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import saphy.saphy.member.domain.Member;
 import saphy.saphy.member.domain.SocialType;
 
@@ -14,4 +17,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Object> findByEmailAndSocialType(String email, SocialType socialType);
 
     Optional<Member> findByLoginIdAndSocialType(String loginId, SocialType socialType);
+
+    @Query("SELECT m FROM Member m LEFT JOIN FETCH m.profileImage WHERE m.id = :memberId")
+    Optional<Member> findWithImagesById(@Param("memberId") Long memberId);
 }

--- a/src/main/java/saphy/saphy/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/saphy/saphy/member/dto/response/MemberInfoResponse.java
@@ -2,6 +2,8 @@ package saphy.saphy.member.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import saphy.saphy.image.domain.ProfileImage;
+import saphy.saphy.image.dto.response.ImageResponse;
 import saphy.saphy.member.domain.Member;
 import saphy.saphy.purchase.domain.PurchaseStatus;
 import saphy.saphy.sales.SalesStatus;
@@ -12,7 +14,7 @@ import java.util.Map;
 @Builder
 public class MemberInfoResponse {
     private String nickname;
-    private String profileImgUrl;
+    private ImageResponse profileImage;
 
     //구매 상태 개수들
     private Long purchasePendingCount;
@@ -27,10 +29,10 @@ public class MemberInfoResponse {
     private Long salesInProgressCount;
     private Long salesCompletedCount;
 
-    public static MemberInfoResponse toDto(Member member, Map<PurchaseStatus, Long> purchaseCounts, Map<SalesStatus, Long> salesCounts) {
+    public static MemberInfoResponse toDto(Member member, ProfileImage profileImage, Map<PurchaseStatus, Long> purchaseCounts, Map<SalesStatus, Long> salesCounts) {
                 return MemberInfoResponse.builder()
                         .nickname(member.getNickName())
-                        //.profileImgUrl(findMember.getProfileImgUrl)
+                        .profileImage(ImageResponse.from(profileImage.getImage()))
                         .deliveryStartedCount(purchaseCounts.get(PurchaseStatus.START))
                         .deliveryGoingCount(purchaseCounts.get(PurchaseStatus.SHIPPED))
                         .deliveryDeliveredCount(purchaseCounts.get(PurchaseStatus.DELIVERED))

--- a/src/main/java/saphy/saphy/member/presentation/MemberController.java
+++ b/src/main/java/saphy/saphy/member/presentation/MemberController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
@@ -14,6 +15,8 @@ import saphy.saphy.auth.domain.CustomUserDetails;
 import saphy.saphy.auth.utils.AccessTokenUtils;
 import saphy.saphy.global.exception.ErrorCode;
 import saphy.saphy.global.response.ApiResponse;
+import saphy.saphy.image.domain.ProfileImage;
+import saphy.saphy.image.service.ImageService;
 import saphy.saphy.member.domain.Member;
 import saphy.saphy.member.dto.request.MemberAccountAddRequest;
 import saphy.saphy.member.dto.request.MemberAccountUpdateRequest;
@@ -33,6 +36,7 @@ import saphy.saphy.member.service.MemberService;
 @Tag(name = "MemberController", description = "회원 관련 API")
 public class MemberController {
     private final MemberService memberService;
+    private final ImageService imageService;
 
     @GetMapping("/test")
     @Operation(summary = "로그인 유지 test", description = "member가 SecurityContext에 저장되었는지 확인하는 API 입니다.")
@@ -78,6 +82,20 @@ public class MemberController {
         @RequestBody MemberInfoUpdateRequest updateRequest) {
         Member loggedInMember = customUserDetails.getMember();
         memberService.updateMemberInfo(loggedInMember, updateRequest);
+        return new ApiResponse<>(ErrorCode.REQUEST_OK);
+    }
+
+    @PatchMapping("/profileImage")
+    @Operation(summary = "회원 프로필 이미지 설정 API", description = "회원의 프로필 이미지를 설정합니다.")
+    public ApiResponse<Void> updateProfileImage(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @RequestPart("profileImage") MultipartFile profileImageFile
+    ) {
+        Member loggedInMember = customUserDetails.getMember();
+        imageService.deleteProfileImage(loggedInMember.getId());
+        ProfileImage profileImage = imageService.saveProfileImage(profileImageFile, loggedInMember.getId());
+        memberService.updateProfileImage(loggedInMember, profileImage);
+
         return new ApiResponse<>(ErrorCode.REQUEST_OK);
     }
 

--- a/src/main/java/saphy/saphy/member/service/MemberService.java
+++ b/src/main/java/saphy/saphy/member/service/MemberService.java
@@ -5,7 +5,6 @@ import static saphy.saphy.global.exception.ErrorCode.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -89,7 +88,7 @@ public class MemberService {
                 .findAll()
                 .stream()
                 .map(MemberDetailResponse::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     // 회원 정보 조회
@@ -97,8 +96,11 @@ public class MemberService {
     public MemberInfoResponse getInfo(Member member) {
         Map<PurchaseStatus, Long> purchaseCounts = purchaseService.getPurchaseCounts(member.getId());
         Map<SalesStatus, Long> salesCounts = salesService.getPurchaseCounts(member.getId());
+        ProfileImage profileImage = profileImageRepository.findByMemberId(member.getId())
+            .orElseThrow(() -> SaphyException.from(PROFILE_IMAGE_NOT_FOUND));
+        Member findMember = profileImage.getMember();
 
-        return MemberInfoResponse.toDto(member, purchaseCounts, salesCounts);
+        return MemberInfoResponse.toDto(findMember, profileImage, purchaseCounts, salesCounts);
     }
 
     // 회원 정보 수정

--- a/src/main/java/saphy/saphy/member/service/MemberService.java
+++ b/src/main/java/saphy/saphy/member/service/MemberService.java
@@ -17,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import saphy.saphy.auth.domain.CustomUserDetails;
 import saphy.saphy.global.exception.ErrorCode;
 import saphy.saphy.global.exception.SaphyException;
+import saphy.saphy.image.domain.ProfileImage;
+import saphy.saphy.image.repository.ProfileImageRepository;
 import saphy.saphy.member.domain.Account;
 import saphy.saphy.member.domain.Address;
 import saphy.saphy.member.domain.Member;
@@ -59,7 +61,16 @@ public class MemberService {
     public void join(MemberJoinRequest request) {
         validateExistMember(request);
         String encodedPassword = bCryptPasswordEncoder.encode(request.getPassword());
+
         Member member = request.toEntity(encodedPassword);
+        ProfileImage defaultProfileImage = ProfileImage.createProfileImage(
+            "default_profile_image.png",
+            "default_profile_image.png",
+            "https://w7.pngwing.com/pngs/665/132/png-transparent-user-defult-avatar.png",
+                member
+            );
+        profileImageRepository.save(defaultProfileImage);
+        member.updateProfileImage(defaultProfileImage);
 
         memberRepository.save(member);
     }

--- a/src/main/java/saphy/saphy/member/service/MemberService.java
+++ b/src/main/java/saphy/saphy/member/service/MemberService.java
@@ -41,6 +41,7 @@ import saphy.saphy.sales.service.SalesService;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final ProfileImageRepository profileImageRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final PurchaseService purchaseService;
     private final SalesService salesService;
@@ -113,6 +114,14 @@ public class MemberService {
         updateIfPresent(request.getEmail(), member::setEmail);
 
         memberRepository.save(member);  // 변경된 내용을 저장합니다.
+    }
+
+    @Transactional
+    public void updateProfileImage(Member member, ProfileImage profileImage) {
+        profileImageRepository.findByMemberId(member.getId())
+            .ifPresent(profileImageRepository::delete);
+
+        member.updateProfileImage(profileImage);
     }
 
     // 회원 탈퇴

--- a/src/main/java/saphy/saphy/sales/dto/request/SalesCreateRequest.java
+++ b/src/main/java/saphy/saphy/sales/dto/request/SalesCreateRequest.java
@@ -9,13 +9,11 @@ import saphy.saphy.sales.domain.Sales;
 
 @Getter
 public class SalesCreateRequest {
-	private Long id;
 	private Long itemId;
 	private DefectRequest defect;
 
 	public Sales toEntity(Member member, Item item) {
 		return Sales.builder()
-				.id(id)
 				.salesStatus(SalesStatus.IN_PROGRESS)
 				.defect(defect.toEntity())
 				.item(item)


### PR DESCRIPTION
## 📄 Summary

> 프로필 이미지 관련 에러로 사용자 프로필 조회 자체가 안됐었는데, 고쳐놨습니다!
> 기존에 연관관계 설정 문제로 계속 member 객체의 profileImage 필드값이 null로 떴었습니다.
> 연관관계 수정(양방향 -> 단방향)과 fetch join을 활용한 프로필 이미지 조회를 통해 문제를 해결했습니다.

## 🕰️ Actual Time of Completion

> 1day

## 🙋🏻 More

> 해결했다 끼얏호우
>
> p.s. 솔직히 지금 이미지 처리 관련 기능이 진짜 개씹 스파게티 코드인데 나중에 리팩토링 해봐야할 것 같습니다.. fuck
