### PR TITLE
SAPHY-182 fix: 판매 엔티티 관련 에러 수정

### DIFF
--- a/src/main/java/saphy/saphy/sales/domain/Defect.java
+++ b/src/main/java/saphy/saphy/sales/domain/Defect.java
@@ -1,5 +1,6 @@
 package saphy.saphy.sales.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,6 +13,7 @@ public class Defect {
 	private String display;
 	private String appearance;
 	private String batteryEfficiency;
+	@Column(name = "`function`")
 	private String function;
 	private String purchaseDate;
 	private String isRepaired;

--- a/src/main/java/saphy/saphy/sales/presentation/SalesController.java
+++ b/src/main/java/saphy/saphy/sales/presentation/SalesController.java
@@ -35,11 +35,11 @@ public class SalesController {
 	public ApiResponse<Void> save(
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		@RequestPart("request") SalesCreateRequest request,
-		@RequestPart("imageFiles") List<MultipartFile> multipartFiles
+		@RequestPart("imageFiles") List<MultipartFile> imageFiles
 	) {
 		Member member = customUserDetails.getMember();
 		Sales sales = salesService.save(member, request);
-		imageService.saveSalesImages(multipartFiles, sales.getId());
+		imageService.saveSalesImages(imageFiles, sales.getId());
 
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}


### PR DESCRIPTION
mysql 명령어와 겹치는 관계로 수정

## 📄 Summary

> 판매 기능이 잘 안 돼서 sales 테이블의 칼럼명을 바꿔봤습니다.
> 솔직히 바꾼 거 ㅈ도 없는데 왜 갑자기 안 되던 게 잘 되는지 모르겠습니다..

## 🕰️ Actual Time of Completion

> 1 day

## 🙋🏻 More

> 끼얏호우~ 해결했다
