### PR TITLE
SAPHY-182 fix: 판매 엔티티 관련 에러 해결 2

### DIFF
--- a/src/main/java/saphy/saphy/sales/domain/Defect.java
+++ b/src/main/java/saphy/saphy/sales/domain/Defect.java
@@ -1,5 +1,6 @@
 package saphy.saphy.sales.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,6 +13,7 @@ public class Defect {
 	private String display;
 	private String appearance;
 	private String batteryEfficiency;
+	@Column(name = "`function`")
 	private String function;
 	private String purchaseDate;
 	private String isRepaired;

--- a/src/main/java/saphy/saphy/sales/domain/Sales.java
+++ b/src/main/java/saphy/saphy/sales/domain/Sales.java
@@ -48,7 +48,7 @@ public class Sales extends BaseEntity {
     @Embedded
     private Defect defect;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_id")
     private Item item;
 

--- a/src/main/java/saphy/saphy/sales/presentation/SalesController.java
+++ b/src/main/java/saphy/saphy/sales/presentation/SalesController.java
@@ -35,11 +35,11 @@ public class SalesController {
 	public ApiResponse<Void> save(
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		@RequestPart("request") SalesCreateRequest request,
-		@RequestPart("imageFiles") List<MultipartFile> multipartFiles
+		@RequestPart("imageFiles") List<MultipartFile> imageFiles
 	) {
 		Member member = customUserDetails.getMember();
 		Sales sales = salesService.save(member, request);
-		imageService.saveSalesImages(multipartFiles, sales.getId());
+		imageService.saveSalesImages(imageFiles, sales.getId());
 
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}


### PR DESCRIPTION
## 📄 Summary

> Sales 엔티티에 연관관계가 @ManyToOne이어야 하는데, @OneToOne 이었어서 같은 Item에 대해 판매를 여러 개 생성하면 key 중복 에러가 났던 것 같습니다! 바로 수정했습니다 😀

## 🕰️ Actual Time of Completion

> 10 min

## 🙋🏻 More

>
